### PR TITLE
feat: enable dark mode site-wide

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -33,7 +33,7 @@ export default function RootLayout({
 }>) {
   return (
     <ClerkProvider>
-      <html lang="en">
+      <html lang="en" className="dark">
         <body
           className={`${geistSans.variable} ${geistMono.variable} antialiased`}
         >


### PR DESCRIPTION
Add 'dark' class to the html element so the entire site uses dark mode by default, leveraging the existing dark mode CSS variables.